### PR TITLE
Implement dual-format meal plan storage (JSON + Markdown)

### DIFF
--- a/.cursor/rules/github-issue-formatting.mdc
+++ b/.cursor/rules/github-issue-formatting.mdc
@@ -1,0 +1,109 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+---
+description: Best practices for creating well-formatted GitHub issues via CLI
+globs: []
+alwaysApply: false
+---
+
+# GitHub Issue Formatting Best Practices
+
+When creating or editing GitHub issues via CLI using `gh issue create` or `gh issue edit`, follow these formatting guidelines to ensure professional, readable issues:
+
+## Issue Structure Template
+
+Every GitHub issue should follow this structure:
+
+```markdown
+## Problem
+Clear, concise description of the current issue or limitation.
+
+## Proposed Solution
+Detailed explanation of what you want to implement or change.
+
+### Implementation Details
+- Specific technical requirements
+- File locations that need changes
+- Architecture considerations
+
+## Acceptance Criteria
+- [ ] Specific, testable requirements using checkboxes
+- [ ] Clear success metrics
+- [ ] Edge cases to consider
+
+## Benefits
+- Clear value proposition
+- Impact on users/developers
+- Long-term advantages
+```
+
+## CLI Best Practices
+
+### Use Body Files for Complex Issues
+- **NEVER** include newlines in command line arguments
+- Create temporary files for issue bodies: `/tmp/issue_body.md`
+- Use `--body-file` flag instead of `--body` for multi-line content
+
+```bash
+# ✅ Correct approach
+gh issue create --title "Feature Title" --body-file /tmp/issue_body.md --label enhancement
+
+# ❌ Wrong approach - will fail
+gh issue create --title "Title" --body "Line 1
+Line 2"
+```
+
+### Markdown Formatting Rules
+- Use clean markdown without raw syntax or excessive escaping
+- Structure with proper headings (`##`, `###`)
+- Use bulleted lists with `-` for readability
+- Include checkboxes for actionable items: `- [ ]`
+- Code references use backticks: `` `function_name` ``
+- File paths use backticks: `` `path/to/file.py` ``
+
+### Content Guidelines
+- **Be specific**: Include exact file paths, function names, and technical details
+- **Use sections**: Break content into logical sections with headings
+- **Include context**: Explain current behavior vs desired behavior
+- **Add examples**: Show before/after code snippets when relevant
+- **List benefits**: Explain why this change matters
+
+## Common Mistakes to Avoid
+
+### Formatting Errors
+- ❌ Wall of text without structure
+- ❌ Raw markdown syntax that doesn't render
+- ❌ Missing headings and sections
+- ❌ Inline commands with newlines
+
+### Content Issues
+- ❌ Vague descriptions without specifics
+- ❌ Missing implementation details
+- ❌ No acceptance criteria
+- ❌ Unclear benefits or value proposition
+
+## Label Strategy
+- Use `enhancement` for new features
+- Use `bug` for defects
+- Use project-specific labels when available
+- Check available labels first: `gh label list`
+
+## Example Commands
+
+```bash
+# Create issue with proper formatting
+echo "Content here..." > /tmp/issue_body.md
+gh issue create --title "Clear, Descriptive Title" --body-file /tmp/issue_body.md --label enhancement
+
+# Edit existing issue
+echo "Updated content..." > /tmp/updated_body.md
+gh issue edit 123 --body-file /tmp/updated_body.md
+
+# Clean up temp files
+rm /tmp/issue_body.md
+```
+
+Remember: Well-formatted issues get faster responses and better collaboration!

--- a/main.py
+++ b/main.py
@@ -134,13 +134,16 @@ async def create_mealplan(meal_plan: MealPlan) -> str:
     from mealplan_mcp.services.mealplan import store_mealplan
     from mealplan_mcp.renderers.mealplan import render_mealplan_summary
 
-    file_path = store_mealplan(meal_plan)
+    markdown_path, json_path = store_mealplan(meal_plan)
 
     # Generate summary for return value
     summary = render_mealplan_summary(meal_plan)
 
     # Add the file path information
-    result = summary + f"\n\nMeal plan saved to: {file_path}"
+    result = (
+        summary
+        + f"\n\nMeal plan saved to:\n  Markdown: {markdown_path}\n  JSON: {json_path}"
+    )
 
     return result
 

--- a/tests/test_create_mealplan_tool.py
+++ b/tests/test_create_mealplan_tool.py
@@ -65,10 +65,12 @@ async def test_create_mealplan_tool_basic(monkeypatch):
         assert "2023-06-15" in result
         assert "Meal plan saved to:" in result
 
-        # Check that the file was actually created
+        # Check that both files were actually created
         expected_dir = mock_mealplan_directory_path(date)
-        expected_file = expected_dir / "06-15-2023-dinner.md"
-        assert expected_file.exists()
+        expected_md_file = expected_dir / "06-15-2023-dinner.md"
+        expected_json_file = expected_dir / "06-15-2023-dinner.json"
+        assert expected_md_file.exists()
+        assert expected_json_file.exists()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
Implements dual-format storage for meal plans, saving both JSON and Markdown files during `create_mealplan` tool calls.

## Changes Made
- **Modified `store_mealplan` function** to return tuple of `(markdown_path, json_path)`
- **Added JSON serialization** using `model_dump_json()` with `cleaned_title` excluded
- **Maintained atomic file operations** for both formats to ensure data integrity
- **Updated all tests** to verify both file formats are created correctly
- **Enhanced `create_mealplan` tool** to report both file paths in response
- **Added comprehensive test coverage** for JSON content validation

## File Structure
Both files use the same base filename with different extensions:
- `{MM-DD-YYYY}-{meal_type}.md` - Human-readable markdown format
- `{MM-DD-YYYY}-{meal_type}.json` - Machine-readable JSON format

## Benefits
- ✅ Better data persistence and backup capabilities
- ✅ Machine-readable format for automation and integration
- ✅ Maintains existing human-readable markdown functionality
- ✅ Enables future features like meal plan editing/loading
- ✅ Consistent file naming and atomic operations

## Testing
- All 72 existing tests pass
- Added JSON content validation to store service tests
- Updated create_mealplan tool tests for dual-format output
- Verified collision handling works for both file types

Closes #46 