### PR TITLE
feat: order meal plans by meal type in PDF exports

### DIFF
--- a/mealplan_mcp/services/mealplan/pdf_export_service.py
+++ b/mealplan_mcp/services/mealplan/pdf_export_service.py
@@ -101,8 +101,17 @@ def get_mealplan_files_with_content(
                                 }
                             )
 
-    # Sort by date, then by meal type, then by title
-    meal_plans.sort(key=lambda x: (x["date"], x["meal_type"], x["title"]))
+    # Define meal type order: breakfast -> lunch -> dinner -> snack
+    meal_type_order = {"breakfast": 0, "lunch": 1, "dinner": 2, "snack": 3}
+
+    # Sort by date, then by meal type order (not alphabetically), then by title
+    meal_plans.sort(
+        key=lambda x: (
+            x["date"],
+            meal_type_order.get(x["meal_type"], 99),  # Default to 99 for unknown types
+            x["title"],
+        )
+    )
     return meal_plans
 
 
@@ -306,7 +315,7 @@ def _generate_pdf_with_reportlab(
 
 
 def _add_markdown_content_to_story(
-    markdown_content: str, story: list, styles: dict
+    markdown_content: str, story: list, styles: Any
 ) -> None:
     """
     Convert markdown content to PDF elements using proper markdown rendering.


### PR DESCRIPTION
## Summary
- Implement custom ordering for meal plans in PDF exports
- Replace alphabetical meal type sorting with logical daily progression: breakfast → lunch → dinner → snack
- Add comprehensive test coverage for the new ordering functionality

## Changes
- Modified `get_mealplan_files_with_content()` to use custom meal type ordering
- Added `meal_type_order` dictionary to define the proper sequence
- Created test `test_meal_plans_ordered_by_meal_type` to verify ordering behavior
- Fixed type annotation for pyright compatibility

## Test plan
- [x] New test verifies meals are ordered correctly within each day
- [x] All existing PDF export tests continue to pass
- [x] Linting and type checking pass
- [x] Full test suite passes (114 tests)

🤖 Generated with [Claude Code](https://claude.ai/code)