### PR TITLE
fix: move mcp[cli] to dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ export MEALPLANPATH="/path/to/meal/plans"
 
 # Install dependencies with uv
 uv venv && source .venv/bin/activate
-uv pip install -e ".[dev]"
+uv pip install -e .
 
 # Run the server
 python main.py
@@ -129,11 +129,15 @@ Add this server configuration to your `claude_desktop_config.json`:
 
 4. Install dependencies:
    ```bash
-   # Using uv (recommended)
+   # For basic usage (recommended)
+   uv pip install -e .
+
+   # For development (includes testing tools)
    uv pip install -e ".[dev]"
 
    # Alternative: Using pip
-   pip install -e ".[dev]"
+   pip install -e .              # Basic usage
+   pip install -e ".[dev]"       # Development
    ```
 
 ### Running the Application

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "httpx>=0.28.1",
-    "mcp[cli]>=1.6.0",
+    "mcp>=1.6.0",
     "fastapi>=0.109.0",
     "pydantic>=2.0.0",
     "python-slugify>=8.0.0",
@@ -25,6 +25,7 @@ dev = [
     "pyright>=1.1.350",
     "httpx>=0.28.1",
     "coverage-badge>=1.1.0",
+    "mcp[cli]>=1.6.0",
 ]
 
 mcp = [


### PR DESCRIPTION
## Summary
Fixes #54 - Users no longer need to install CLI tools just to run the server.

## Problem
The current setup requires all users to install `mcp[cli]` (including CLI development tools) even when they only want to run the MCP server. This causes unnecessary dependency bloat for basic usage.

## Solution
- Move `mcp[cli]` from core dependencies to dev dependencies
- Keep `mcp` (without `[cli]`) as core dependency for server functionality
- Update README with separate installation instructions for basic usage vs development

## Changes
- **pyproject.toml**: Move `mcp[cli]>=1.6.0` to `dev` optional dependencies
- **pyproject.toml**: Change core dependency to `mcp>=1.6.0` (without CLI extras)
- **README.md**: Update Quick Start to use `uv pip install -e .` for basic usage
- **README.md**: Update Development Setup with separate commands for basic vs dev installation

## Usage
**Basic users** (just want to run the server):
```bash
uv pip install -e .
```

**Developers** (want testing/CLI tools):
```bash
uv pip install -e ".[dev]"
```

## Test plan
- [x] Core server functionality works with `mcp` (without CLI)
- [x] Server starts successfully with basic installation
- [x] Dev dependencies still include `mcp[cli]` for development workflows
- [x] README instructions are clear for both use cases

Closes #54

🤖 Generated with [Claude Code](https://claude.ai/code)